### PR TITLE
Improved DashAppLoadingError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versions follow [Semantic Versioning](https://www.semver.org)
 - `DashAppLoadingError` [#23](https://github.com/T4rk1n/pytest-dash/pull/23)
   - Display the body html
   - Display console logs
+  - Catch common errors early. [#33](https://github.com/T4rk1n/pytest-dash/pull/33)
+  - Loop wait_for `#_dash-app-conten`t and retry the url. [#33](https://github.com/T4rk1n/pytest-dash/pull/33)
+  - Added `start_wait_time` and `start_timeout` to `dash_threaded` [#33](https://github.com/T4rk1n/pytest-dash/pull/33)
 - Add port option to `dash_threaded` and `dash_subprocess`. [#28](https://github.com/T4rk1n/pytest-dash/pull/23)
 - Add `start_wait_time` option to `dash_threadred` for waiting after starting the thread, default to 1 sec. [#28](https://github.com/T4rk1n/pytest-dash/pull/23)
 

--- a/pytest_dash/fixtures.py
+++ b/pytest_dash/fixtures.py
@@ -33,7 +33,7 @@ def _stop_server():
 
 
 def _wait_for_client_app_started(driver, url,  wait_time=0.5, timeout=10):
-    # Wait until the react-entry-point is loaded.
+    # Wait until the #_dash-app-content element is loaded.
     start_time = time.time()
     loading_errors = (
         'error loading layout',

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,6 +1,7 @@
 try:
     from queue import Queue, Empty
 except ImportError:
+    # noinspection PyUnresolvedReferences
     from Queue import Queue, Empty
 
 import pytest
@@ -10,7 +11,7 @@ from dash.exceptions import PreventUpdate
 import dash_html_components as html
 
 from pytest_dash.fixtures import dash_threaded, dash_subprocess
-from pytest_dash.errors import NoAppFoundError
+from pytest_dash.errors import NoAppFoundError, DashAppLoadingError
 from pytest_dash.utils import \
     wait_for_text_to_equal, wait_for_element_by_css_selector, import_app
 
@@ -44,6 +45,14 @@ def test_dash_threaded(dash_threaded, selenium):
         wait_for_text_to_equal(selenium, '#output', str(i + 1))
 
     assert call_count.qsize() == 7
+
+
+def test_invalid_start_raises(dash_threaded):
+    app = dash.Dash(__name__)
+
+    # Start the server without setting the layout.
+    with pytest.raises(DashAppLoadingError):
+        dash_threaded(app, start_timeout=1)
 
 
 @pytest.mark.skipif('os.environ.get("CIRCLECI")',


### PR DESCRIPTION
- Catch common errors early.
- Loop wait_for `#_dash-app-content` and retry the url.
- Added `start_wait_time` and `start_timeout` to `dash_threaded`

Resolves #31 