### PR TITLE
Fixed _assert_closed function

### DIFF
--- a/pytest_dash/application_runners.py
+++ b/pytest_dash/application_runners.py
@@ -26,12 +26,15 @@ def _stop_server():
     stopper()
     return 'stop'
 
-
 def _assert_closed(driver):
+    import urllib
+    from urllib.error import URLError
     driver.refresh()
-    body = driver.find_element_by_css_selector('body').text
-    return 'refused to connect' in body or not body
-
+    try:
+        urllib.request.urlopen(driver.current_url)
+    except URLError:
+        return True
+    return False
 
 def _handle_error(_):
     _stop_server()

--- a/pytest_dash/application_runners.py
+++ b/pytest_dash/application_runners.py
@@ -30,7 +30,6 @@ def _stop_server():
 
 
 def _assert_closed(driver):
-    driver.refresh()
     try:
         urllib.request.urlopen(driver.current_url)
     except URLError:

--- a/pytest_dash/application_runners.py
+++ b/pytest_dash/application_runners.py
@@ -9,6 +9,7 @@ import subprocess
 import time
 import uuid
 import urllib
+from urllib.error import URLError
 import threading
 import sys
 
@@ -17,7 +18,6 @@ import requests
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.wait import WebDriverWait
-from urllib.error import URLError
 
 from pytest_dash import errors
 from pytest_dash.wait_for import _wait_for_client_app_started

--- a/pytest_dash/application_runners.py
+++ b/pytest_dash/application_runners.py
@@ -26,6 +26,7 @@ def _stop_server():
     stopper()
     return 'stop'
 
+
 def _assert_closed(driver):
     import urllib
     from urllib.error import URLError
@@ -35,6 +36,7 @@ def _assert_closed(driver):
     except URLError:
         return True
     return False
+
 
 def _handle_error(_):
     _stop_server()

--- a/pytest_dash/application_runners.py
+++ b/pytest_dash/application_runners.py
@@ -8,6 +8,7 @@ import shlex
 import subprocess
 import time
 import uuid
+import urllib
 import threading
 import sys
 
@@ -16,6 +17,7 @@ import requests
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.wait import WebDriverWait
+from urllib.error import URLError
 
 from pytest_dash import errors
 from pytest_dash.wait_for import _wait_for_client_app_started
@@ -28,8 +30,6 @@ def _stop_server():
 
 
 def _assert_closed(driver):
-    import urllib
-    from urllib.error import URLError
     driver.refresh()
     try:
         urllib.request.urlopen(driver.current_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-dash==0.36.0
-dash-html-components==0.13.4
-dash-core-components==0.43.0
-dash-renderer==0.17.0
+dash==0.39.0
 selenium
 pytest
 requests


### PR DESCRIPTION
Hi, thanks for making a great plugin!!

I had tried to test my dash app with your library, but found out that one of the function for checking whether the server was closed was not working on my environment (Mint Linux 19.01 with Chrome 73).

It might be simply because I am using Chrome in Japanese language environment. The body showed following Japanese texts. I suupose texts would deffere in defferent language enviroment.

```
このサイトにアクセスできません
localhost で接続が拒否されました。
次をお試しください:
接続を確認する
プロキシとファイアウォールを確認する
ERR_CONNECTION_REFUSED
再読み込み
詳細
```

My fix simply requests server url and  assumes the server is turned off if we get URLError.